### PR TITLE
updated extensions and context to model

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To make the usage simpler spacy provides custom extesnions which a library can u
 | Extension | Type | Description | Default |
 |-------------------------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
 | span._.get_has_spellCheck | `Boolean` | To check whether contextualSpellCheck identified any misspells and performed correction in this span | `False` |
-| span._.score_spellCheck | `{Spacy.Token:List(str,float)}` | if corrections are performed, it returns the mapping of misspell token (`spaCy.Token`) with suggested words(`str`) and probability of that correction for tokens in this `span` | `[{spaCy.Token: []}]` |
+| span._.score_spellCheck | `{Spacy.Token:List(str,float)}` | if corrections are performed, it returns the mapping of misspell token (`spaCy.Token`) with suggested words(`str`) and probability of that correction for tokens in this `span` | `{spaCy.Token: []}` |
 
 ### `spaCy.Token` level extensions
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To make the usage simpler spacy provides custom extesnions which a library can u
 |------------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | doc._.contextual_spellCheck | `Boolean` | To check whether contextualSpellCheck is added as extension | `True` |
 | doc._.performed_spellCheck | `Boolean` | To check whether contextualSpellCheck identified any misspells and performed correction | `False` |
-| doc._.suggestions_spellCheck | `{Spacy.Token:List(str)}` | if corrections are performed, it returns the mapping of misspell token (`spaCy.Token`) with suggested words(`str`) | `{}` |
+| doc._.suggestions_spellCheck | `{Spacy.Token:str}` | if corrections are performed, it returns the mapping of misspell token (`spaCy.Token`) with suggested word(`str`) | `{}` |
 | doc._.outcome_spellCheck | `str` | corrected sentence(`str`) as output | `""` |
 | doc._.score_spellCheck | `{Spacy.Token:List(str,float)}` | if corrections are performed, it returns the mapping of misspell token (`spaCy.Token`) with suggested words(`str`) and probability of that correction | `None` |
 
@@ -117,9 +117,9 @@ To make the usage simpler spacy provides custom extesnions which a library can u
 ### `spaCy.Token` level extensions
 
 | Extension | Type | Description | Default |
-|-----------------------------------|---------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+|-----------------------------------|-----------------|-------------------------------------------------------------------------------------------------------------|---------|
 | token._.get_require_spellCheck | `Boolean` | To check whether contextualSpellCheck identified any misspells and performed correction on this `token` | `False` |
-| token._.get_suggestion_spellCheck | `{Spacy.Token:List(str)}` | if corrections are performed, it returns list of suggested words(`str`) | `[]` |
+| token._.get_suggestion_spellCheck | `str` | if corrections are performed, it returns the suggested word(`str`) | `""` |
 | token._.score_spellCheck | `[(str,float)]` | if corrections are performed, it returns suggested words(`str`) and probability(`float`) of that correction | `[]` |
 
 ## API

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -194,7 +194,6 @@ class ContextualSpellCheck(object):
             mask_token_index = torch.where(
                 model_input == self.BertTokenizer.mask_token_id
             )[1]
-            print(mask_token_index)
             token_logits = self.BertModel(model_input)[0]
             mask_token_logits = token_logits[0, mask_token_index, :]
             token_probability = torch.nn.functional.softmax(mask_token_logits, dim=1)
@@ -340,9 +339,9 @@ class ContextualSpellCheck(object):
             span {`Spacy.Span`} -- Span object for which value should be returned
 
         Returns:
-            List(Dict(`Token`:List(str,int))) -- for every token it will return (suggestion,score) eg: [{token-1: []}, {token-2: []}, {token-3: [('suggestion-1', score-1),]}] 
+            Dict(`Token`:List(str,int)) -- for every token it will return (suggestion,score) eg: {token-1: [], token-2: [], token-3: [('suggestion-1', score-1), ...], ...} 
         """
-        return [{token: self.token_score_spellCheck(token)} for token in span]
+        return {token: self.token_score_spellCheck(token) for token in span}
 
     def span_require_spellCheck(self, span):
         """Getter for Span Object

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -268,7 +268,7 @@ class ContextualSpellCheck(object):
             if self.debug:
                 print("response[misspell]", response[misspell])
 
-        if len(response)>0:
+        if len(response) > 0:
             tempToken.doc._.set("suggestions_spellCheck", response)
         return response
 

--- a/contextualSpellCheck/tests/test_contextualSpellCheck.py
+++ b/contextualSpellCheck/tests/test_contextualSpellCheck.py
@@ -250,7 +250,10 @@ def test_extension2_candidateGenerator(inputSentence, misspell):
     doc = nlp(inputSentence)
     (misspellings, doc) = checker.misspellIdentify(doc)
     suggestions = checker.candidateGenerator(doc, misspellings)
-    assert doc._.score_spellCheck.keys() == {doc[key]: value for key, value in misspell.items()}.keys()
+    assert (
+        doc._.score_spellCheck.keys()
+        == {doc[key]: value for key, value in misspell.items()}.keys()
+    )
     assert [
         word_score[0]
         for value in doc._.score_spellCheck.values()

--- a/contextualSpellCheck/tests/test_contextualSpellCheck.py
+++ b/contextualSpellCheck/tests/test_contextualSpellCheck.py
@@ -7,7 +7,7 @@ from contextualSpellCheck.contextualSpellCheck import ContextualSpellCheck
 # This is the class we want to test. So, we need to import it
 
 
-nlp = spacy.load("en_core_web_sm", disable=["tagger", "parser"])
+nlp = spacy.load("en_core_web_sm")
 
 checker = ContextualSpellCheck()  # instantiate the Person Class
 
@@ -285,30 +285,8 @@ def test_doc_extensions():
     doc = nlp(u"Income was $9.4 milion compared to the prior year of $2.7 milion.")
 
     gold_suggestion = {
-        doc[4]: [
-            "million",
-            "billion",
-            ",",
-            "trillion",
-            "Million",
-            "%",
-            "##M",
-            "annually",
-            "##B",
-            "USD",
-        ],
-        doc[13]: [
-            "billion",
-            "million",
-            "trillion",
-            "##M",
-            "Million",
-            "##B",
-            "USD",
-            "##b",
-            "millions",
-            "%",
-        ],
+        doc[4]: "million",
+        doc[13]: "million",
     }
     gold_outcome = "Income was $9.4 million compared to the prior year of $2.7 million."
     gold_score = {
@@ -346,7 +324,10 @@ def test_doc_extensions():
 
 
 def test_span_extensions():
-    nlp.add_pipe(checker)
+    try:
+        nlp.add_pipe(checker)
+    except:
+        print("contextual SpellCheck already in pipeline")
     doc = nlp("Income was $9.4 milion compared to the prior year of $2.7 milion.")
 
     gold_score = [
@@ -379,18 +360,7 @@ def test_token_extension():
         nlp.add_pipe(checker)
     doc = nlp("Income was $9.4 milion compared to the prior year of $2.7 milion.")
 
-    gold_suggestions = [
-        "million",
-        "billion",
-        ",",
-        "trillion",
-        "Million",
-        "%",
-        "##M",
-        "annually",
-        "##B",
-        "USD",
-    ]
+    gold_suggestions = "million"
     gold_score = [
         ("million", 0.59422),
         ("billion", 0.24349),

--- a/contextualSpellCheck/tests/test_contextualSpellCheck.py
+++ b/contextualSpellCheck/tests/test_contextualSpellCheck.py
@@ -250,9 +250,21 @@ def test_extension2_candidateGenerator(inputSentence, misspell):
     doc = nlp(inputSentence)
     (misspellings, doc) = checker.misspellIdentify(doc)
     suggestions = checker.candidateGenerator(doc, misspellings)
-    assert doc._.score_spellCheck == {
-        doc[key]: value for key, value in misspell.items()
-    }
+    assert doc._.score_spellCheck.keys() == {doc[key]: value for key, value in misspell.items()}.keys()
+    assert [
+        word_score[0]
+        for value in doc._.score_spellCheck.values()
+        for word_score in value
+    ] == [word_score[0] for value in misspell.values() for word_score in value]
+    assert [
+        word_score[1]
+        for value in doc._.score_spellCheck.values()
+        for word_score in value
+    ] == approx(
+        [word_score[1] for value in misspell.values() for word_score in value],
+        rel=1e-4,
+        abs=1e-4,
+    )
 
 
 @pytest.mark.parametrize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==1.4.0
-editdistance==0.5.3
-Flask==1.1.2
-transformers==2.8.0
-spacy==2.2.3
-pytest==5.4.2
+torch
+editdistance
+Flask
+transformers
+spacy
+pytest


### PR DESCRIPTION
1. Context changed from Doc to Span (sentence) in `candidateGenerator` hence `parser` is required
2. doc._.outcome_spellCheck extension will now be a getter
3. doc._.suggestions_spellCheck is now set during the call to `candidateRanking`
4. Updated suggestions_spellCheck response from {spaCy.Token: List(str)} to {spaCy.Token: str} as score_spellcheck extension was also giving similar data
5. `misspellIdentify` updated with new conditions