### PR TITLE
Update to spacyv3

### DIFF
--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -14,7 +14,7 @@ from transformers import AutoModelForMaskedLM, AutoTokenizer
 from spacy.language import Language
 
 
-@Language.factory("contextual_spellchecker")
+@Language.factory("contextual spellchecker")
 class ContextualSpellCheck(object):
     """
     Class object for Out Of Vocabulary(OOV) corrections
@@ -655,8 +655,10 @@ if __name__ == "__main__":
         raise AttributeError(
             "parser is required please enable it in nlp pipeline"
         )
-#    checker = ContextualSpellCheck(debug=True, max_edit_dist=3)
-    nlp.add_pipe("contextual_spellchecker", config={'debug':True, 'max_edit_dist':3})
+    #    checker = ContextualSpellCheck(debug=True, max_edit_dist=3)
+    nlp.add_pipe(
+        "contextual_spellchecker", config={"debug": True, "max_edit_dist": 3}
+    )
 
     # nlp.add_pipe(merge_ents)
 

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -655,8 +655,9 @@ if __name__ == "__main__":
         raise AttributeError(
             "parser is required please enable it in nlp pipeline"
         )
-    checker = ContextualSpellCheck(debug=True, max_edit_dist=3)
-    nlp.add_pipe(checker)
+#    checker = ContextualSpellCheck(debug=True, max_edit_dist=3)
+    nlp.add_pipe("contextual_spellchecker", config={'debug':True, 'max_edit_dist':3})
+
     # nlp.add_pipe(merge_ents)
 
     doc = nlp(

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -11,8 +11,10 @@ import torch
 from spacy.tokens import Doc, Token, Span
 from spacy.vocab import Vocab
 from transformers import AutoModelForMaskedLM, AutoTokenizer
+from spacy.language import Language
 
 
+@Language.factory("contextual_spellchecker")
 class ContextualSpellCheck(object):
     """
     Class object for Out Of Vocabulary(OOV) corrections
@@ -22,6 +24,8 @@ class ContextualSpellCheck(object):
 
     def __init__(
         self,
+        nlp,
+        name,
         vocab_path="",
         model_name="bert-base-cased",
         max_edit_dist=10,

--- a/contextualSpellCheck/tests/test_contextualSpellCheck.py
+++ b/contextualSpellCheck/tests/test_contextualSpellCheck.py
@@ -12,7 +12,9 @@ from ..contextualSpellCheck import ContextualSpellCheck
 
 nlp = spacy.load("en_core_web_sm")
 
-checker = ContextualSpellCheck()  # instantiate the Person Class
+checker = ContextualSpellCheck(
+    nlp, "contextual spellchecker"
+)  # instantiate the Person Class
 
 
 @pytest.mark.parametrize(
@@ -335,7 +337,7 @@ def test_ranking_candidateRanking(inputSentence, misspell):
 
 
 def test_compatible_spacyPipeline():
-    nlp.add_pipe(checker)
+    nlp.add_pipe("contextual spellchecker")
     assert "contextual spellchecker" in nlp.pipe_names
 
     nlp.remove_pipe("contextual spellchecker")
@@ -343,7 +345,7 @@ def test_compatible_spacyPipeline():
 
 
 def test_doc_extensions():
-    nlp.add_pipe(checker)
+    nlp.add_pipe("contextual spellchecker")
     doc = nlp(
         "Income was $9.4 milion compared to the prior year of $2.7 milion."
     )
@@ -424,7 +426,7 @@ def test_doc_extensions():
 
 def test_span_extensions():
     try:
-        nlp.add_pipe(checker)
+        nlp.add_pipe("contextual spellchecker")
     except BaseException:
         print("contextual SpellCheck already in pipeline")
     doc = nlp(
@@ -482,7 +484,7 @@ def test_span_extensions():
 
 def test_token_extension():
     if "contextual spellchecker" not in nlp.pipe_names:
-        nlp.add_pipe(checker)
+        nlp.add_pipe("contextual spellchecker")
     doc = nlp(
         "Income was $9.4 milion compared to the prior year of $2.7 milion."
     )
@@ -516,10 +518,11 @@ def test_token_extension():
 
 
 def test_warning():
+    nlp = spacy.load("en_core_web_sm")
     if "contextual spellchecker" not in nlp.pipe_names:
-        nlp.add_pipe(checker)
-    merge_ents = nlp.create_pipe("merge_entities")
-    nlp.add_pipe(merge_ents)
+        nlp.add_pipe("contextual spellchecker")
+    # merge_ents = nlp.create_pipe("merge_entities")
+    nlp.add_pipe("merge_entities")
     doc = nlp(
         "Income was $9.4 milion compared to the prior year of $2.7 milion."
     )
@@ -548,7 +551,8 @@ element in pipeline eg. merge_entities"
         # warnings.simplefilter("default")
 
         with pytest.raises(TypeError) as e:
-            ContextualSpellCheck(vocab_path=True)
+            nlp = spacy.load("en_core_web_sm")
+            ContextualSpellCheck(nlp, "contextualSpellCheck", vocab_path=True)
             assert (
                 e
                 == "Please check datatype provided. \
@@ -556,7 +560,10 @@ vocab_path should be str, debug and performance should be bool"
             )
         max_edit_distance = "non_int_or_float"
         with pytest.raises(ValueError) as e:
-            ContextualSpellCheck(max_edit_dist=max_edit_distance)
+            nlp = spacy.load("en_core_web_sm")
+            ContextualSpellCheck(
+                nlp, "contextualSpellCheck", max_edit_dist=max_edit_distance
+            )
             assert (
                 e
                 == f"cannot convert {max_edit_distance} to int. \
@@ -564,14 +571,18 @@ Please provide a valid integer"
             )
 
     try:
-        ContextualSpellCheck(max_edit_dist="3.1")
+        nlp = spacy.load("en_core_web_sm")
+        ContextualSpellCheck(nlp, "contextualSpellCheck", max_edit_dist="3.1")
     except Exception as uncatched_error:
         pytest.fail(str(uncatched_error))
 
 
 def test_vocab_file():
     with warnings.catch_warnings(record=True) as w:
-        ContextualSpellCheck(vocab_path="testing.txt")
+        nlp = spacy.load("en_core_web_sm")
+        ContextualSpellCheck(
+            nlp, "contextualSpellCheck", vocab_path="testing.txt"
+        )
         assert any([issubclass(i.category, UserWarning) for i in w])
         assert any(["Using default vocab" in str(i.message) for i in w])
     currentPath = os.path.dirname(__file__)
@@ -579,7 +590,10 @@ def test_vocab_file():
     orgDebugFilePath = os.path.join(currentPath, "originaldebugFile.txt")
     testVocab = os.path.join(currentPath, "testVocab.txt")
     print(testVocab, currentPath, debugPathFile)
-    ContextualSpellCheck(vocab_path=testVocab, debug=True)
+    nlp = spacy.load("en_core_web_sm")
+    ContextualSpellCheck(
+        nlp, "contextualSpellCheck", vocab_path=testVocab, debug=True
+    )
     with open(orgDebugFilePath) as f1:
         with open(debugPathFile) as f2:
             assert f1.read() == f2.read()
@@ -596,14 +610,16 @@ containing a config.json  file\n\n"
     )
 
     with pytest.raises(OSError) as e:
-        ContextualSpellCheck(model_name=model_name)
+        nlp = spacy.load("en_core_web_sm")
+        ContextualSpellCheck(nlp, "contextualSpellCheck", model_name=model_name)
         assert e == error_message
 
 
 def test_correct_model_name():
     model_name = "TurkuNLP/bert-base-finnish-cased-v1"
     try:
-        ContextualSpellCheck(model_name=model_name)
+        nlp = spacy.load("en_core_web_sm")
+        ContextualSpellCheck(nlp, "contextualSpellCheck", model_name=model_name)
     except OSError:
         pytest.fail("Specificed model is not present in transformers")
     except Exception as uncatched_error:
@@ -615,10 +631,13 @@ def test_correct_model_name():
     [(0, False), (1, False), (2, True), (3, True)],
 )
 def test_max_edit_dist(max_edit_distance, expected_spell_check_flag):
+    nlp = spacy.load("en_core_web_sm")
     if "contextual spellchecker" in nlp.pipe_names:
         nlp.remove_pipe("contextual spellchecker")
-    checker_edit_dist = ContextualSpellCheck(max_edit_dist=max_edit_distance)
-    nlp.add_pipe(checker_edit_dist)
+    # checker_edit_dist = ContextualSpellCheck(max_edit_dist=max_edit_distance)
+    nlp.add_pipe(
+        "contextual spellchecker", config={"max_edit_dist": max_edit_distance}
+    )
     doc = nlp(
         "Income was $9.4 milion compared to the prior year of $2.7 milion."
     )
@@ -675,8 +694,8 @@ def test_doc_extensions_bug(
     misspell_suggestion,
 ):
     nlp_lg = spacy.load("en_core_web_lg")
-    checker_deep_tokenize = ContextualSpellCheck(max_edit_dist=3)
-    nlp_lg.add_pipe(checker_deep_tokenize)
+    # checker_deep_tokenize = ContextualSpellCheck(nlp,"contextualSpellCheck",max_edit_dist=3)
+    nlp_lg.add_pipe("contextual spellchecker", config={"max_edit_dist": 3})
     doc = nlp_lg(input_sentence)
 
     # To check the status of `performed_spell_check` flag

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-spacy<3.0.0
+spacy>=3.0.0
 editdistance
 pytest
 torch

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,10 @@ setuptools.setup(
         "Development Status :: 4 - Beta",
     ],
     python_requires=">=3.6",
-    install_requires=["torch", "editdistance", "transformers", "spacy < 3.0.0"],
+    install_requires=[
+        "torch",
+        "editdistance",
+        "transformers",
+        "spacy >= 3.0.0",
+    ],
 )


### PR DESCRIPTION
… v3. See: https://nightly.spacy.io/usage/v3#migrating-add-pipe

<!--- Thank you for your contribution to contextualSpellCheck repo!  --->

### Description
- Issue this PR address?
- Any other information you think is relevant

Updated ContextualSpellChecker to work with spacy-v3. This is needed as spacy has changed how to add components to the pipeline: https://nightly.spacy.io/usage/v3#migrating-add-pipe

To run this code with spacy v3, a string "contextual_spellchecker" is passsed to add_pipe instead of the ContextualSpellChecker object.

### Checklist

- [x] Added and/or updated the test (not required for documentation changes)
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information

<!--- This template is inspired from spaCy --->

