### PR TITLE
replace editdistance with rapidfuzz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask
 spacy>=3.0.0
-editdistance==0.5.3
+rapidfuzz==1.4.1
 pytest
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch>=1.4

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "torch>=1.4",
-        "editdistance==0.5.3",
+        "rapidfuzz==1.4.1",
         "transformers>=4.0.0",
         "spacy>=3.0.0",
     ],


### PR DESCRIPTION
This PR replaces editdistance with RapidFuzz (disclaimer: I am the author). RapidFuzz has a faster Levenshtein implementation and in addition provides a function `process.extractOne`, which searches for the choice with the highest similarity/smallest edit distance in a list of choices. This is allows the use of a couple of optimizations and saves a lot of function call overhead from Python making it a lot faster.