### PR TITLE
ENH -- Bump Supported Python Versions to 3.9+

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Contextual word checker for better suggestions
 
 [![license](https://img.shields.io/github/license/r1j1t/contextualSpellCheck)](https://github.com/R1j1t/contextualSpellCheck/blob/master/LICENSE) 
 [![PyPI](https://img.shields.io/pypi/v/contextualSpellCheck?color=green)](https://pypi.org/project/contextualSpellCheck/) 
-[![Python-Version](https://img.shields.io/badge/Python-3.6+-green)](https://github.com/R1j1t/contextualSpellCheck#install)
+[![Python-Version](https://img.shields.io/badge/Python-3.9+-green)](https://github.com/R1j1t/contextualSpellCheck#install)
 [![Downloads](https://pepy.tech/badge/contextualspellcheck/week)](https://pepy.tech/project/contextualspellcheck)
 [![GitHub contributors](https://img.shields.io/github/contributors/r1j1t/contextualSpellCheck)](https://github.com/R1j1t/contextualSpellCheck/graphs/contributors)
 [![Help Wanted](https://img.shields.io/badge/Help%20Wanted-Task%20List-violet)](https://github.com/R1j1t/contextualSpellCheck#task-list)

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -92,7 +92,7 @@ class ContextualSpellCheck(object):
                     debug_file_path = os.path.join(
                         current_path, "tests", "debugFile.txt"
                     )
-                    with open(debug_file_path, "w+") as new_file:
+                    with open(debug_file_path, "w+", encoding="utf8") as new_file:
                         new_file.write("\n".join(words))
                     print("Final vocab at " + debug_file_path)
 

--- a/contextualSpellCheck/contextualSpellCheck.py
+++ b/contextualSpellCheck/contextualSpellCheck.py
@@ -92,7 +92,9 @@ class ContextualSpellCheck(object):
                     debug_file_path = os.path.join(
                         current_path, "tests", "debugFile.txt"
                     )
-                    with open(debug_file_path, "w+", encoding="utf8") as new_file:
+                    with open(
+                        debug_file_path, "w+", encoding="utf8"
+                    ) as new_file:
                         new_file.write("\n".join(words))
                     print("Final vocab at " + debug_file_path)
 

--- a/contextualSpellCheck/tests/test_contextualSpellCheck.py
+++ b/contextualSpellCheck/tests/test_contextualSpellCheck.py
@@ -593,8 +593,8 @@ def test_vocab_file():
     ContextualSpellCheck(
         nlp, "contextualSpellCheck", vocab_path=testVocab, debug=True
     )
-    with open(orgDebugFilePath) as f1:
-        with open(debugPathFile) as f2:
+    with open(orgDebugFilePath, encoding="utf8") as f1:
+        with open(debugPathFile, encoding="utf8") as f2:
             assert f1.read() == f2.read()
 
 


### PR DESCRIPTION


<!--- Thank you for your contribution to contextualSpellCheck repo!  --->

### Description
- Issue this PR address?
> #99 

- Any other information you think is relevant
> modified:   .github/workflows/python-package.yml
> - Removed 3.6, 3.7, and 3.8 from `matrix.python-version` and added 3.10, 3.11, 3.12, and 3.13.
>
> modified:   README.md
> - Changed supported Python versions from 3.6+ to 3.9+.



### Checklist

- [ ] Added and/or updated the test (not required for documentation changes)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information

<!--- This template is inspired from spaCy --->

